### PR TITLE
Update pricing packages and remove digital report references

### DIFF
--- a/index.html
+++ b/index.html
@@ -356,24 +356,24 @@
         <div class="section-header">
           <span class="section-eyebrow">Services</span>
           <h2>Everything your engine needs without leaving home.</h2>
-          <p>Every evening visit includes fluid top-offs, multi-point checks, and a digital service recap so you know exactly what was serviced before bedtime.</p>
+          <p>Every evening visit includes fluid top-offs, tire pressure set to spec, and both engine air and cabin filter checks so you know your daily driver is ready for tomorrow.</p>
         </div>
 
         <div class="cards-grid">
           <article class="card">
             <span class="pill">Conventional</span>
             <h3>Essential Evening Change</h3>
-            <p>Quality conventional oil up to 5 quarts, OEM filter, tire pressure set, and fluid top-offs — perfect for daily drivers who want dependable care after work.</p>
+            <p>Quality conventional oil up to 5 quarts, OEM filter, tire pressure dialed in, and fluids topped off — perfect for daily drivers who want dependable care after work.</p>
           </article>
           <article class="card">
             <span class="pill">Synthetic blend</span>
             <h3>Balanced Performance Plan</h3>
-            <p>Synthetic blend oil for extra protection, cabin filter check, battery test, and windshield wash refill — handled while you finish dinner.</p>
+            <p>Synthetic blend oil for extra protection, comprehensive air and cabin filter checks, battery test, and windshield wash refill — handled while you finish dinner.</p>
           </article>
           <article class="card">
             <span class="pill">Full synthetic</span>
             <h3>Pennzoil Premium Service</h3>
-            <p>Full Synthetic Pennzoil (or your preferred brand), extended-life filter options, multi-point inspection, and digital service log delivered to your inbox.</p>
+            <p>Full Synthetic Pennzoil (or your preferred brand), extended-life filter options, and thorough multi-point inspection with every fluid and tire pressure check included.</p>
           </article>
         </div>
       </div>
@@ -390,40 +390,41 @@
         <div class="pricing">
           <article class="pricing-tier">
             <span class="pill">Conventional</span>
-            <strong>$59–79</strong>
-            <p style="margin:0; color:var(--muted);">Up to 5 quarts of high-quality conventional oil with OEM filter, fluids topped off, and driveway-safe cleanup.</p>
+            <strong>$59.99</strong>
+            <p style="margin:0; color:var(--muted);">Up to 5 quarts of high-quality conventional oil with OEM filter, fluids topped off, and driveway-safe cleanup. Additional oil is $7.99 per quart.</p>
             <ul>
               <li>Includes OEM filter</li>
-              <li>Tire pressure set to spec</li>
-              <li>Digital service recap emailed</li>
+              <li>Air &amp; cabin filter checks included</li>
+              <li>Tire pressure set to spec and fluids topped off</li>
             </ul>
             <a class="btn btn-outline" href="tel:+13463647856">Book this package</a>
           </article>
 
           <article class="pricing-tier featured">
             <span class="pill">Synthetic blend</span>
-            <strong>$69–99</strong>
-            <p style="margin:0; color:var(--muted);">Up to 6 quarts of synthetic blend oil, premium filter, and coolant plus washer fluid top-offs.</p>
+            <strong>$85.99</strong>
+            <p style="margin:0; color:var(--muted);">Up to 5 quarts of synthetic blend oil, premium filter, coolant and washer fluid top-offs, and additional oil at $7.99 per quart.</p>
             <ul>
               <li>Includes battery health check</li>
-              <li>Service reminder reset</li>
-              <li>Available for cars, SUVs, and light trucks</li>
+              <li>Air &amp; cabin filter checks included</li>
+              <li>Tire pressure set to spec for cars, SUVs, and light trucks</li>
             </ul>
             <a class="btn btn-outline" href="sms:+13463647856">Text for availability</a>
           </article>
 
           <article class="pricing-tier">
             <span class="pill">Full synthetic</span>
-            <strong>$89–129</strong>
-            <p style="margin:0; color:var(--muted);">Full Synthetic Pennzoil (or your preferred brand) up to 7 quarts, extended-life filter, and full inspection.</p>
+            <strong>$109.99</strong>
+            <p style="margin:0; color:var(--muted);">Full Synthetic Pennzoil (or your preferred brand) up to 5 quarts with extended-life filter. Additional oil is $7.99 per quart.</p>
             <ul>
-              <li>Includes cabin filter check</li>
-              <li>Multi-point digital report</li>
-              <li>Perfect for high-mileage or performance vehicles</li>
+              <li>Includes thorough multi-point inspection</li>
+              <li>Air &amp; cabin filter checks included</li>
+              <li>Tire pressure set to spec and fluids topped off</li>
             </ul>
             <a class="btn btn-outline" href="mailto:sundayjanitorial@gmail.com">Email to specify your oil</a>
           </article>
         </div>
+        <p style="margin-top:2rem; color:var(--muted); text-align:center;">Every package includes up to 5 quarts of oil. Need more? It's just $7.99 per extra quart.</p>
       </div>
     </section>
 
@@ -534,7 +535,7 @@
           <article class="step">
             <strong>04</strong>
             <h3>Review</h3>
-            <p>We send a digital checklist, dispose of used oil responsibly, and remind you before your next service is due.</p>
+            <p>We walk you through the work, dispose of used oil responsibly, and remind you before your next service is due.</p>
           </article>
         </div>
       </div>
@@ -550,7 +551,7 @@
 
         <div class="testimonials">
           <article class="testimonial">
-            <p>“They showed up after dinner, laid down mats, and had my SUV buttoned up in 40 minutes. The full report hit my inbox before I went to bed.”</p>
+            <p>“They showed up after dinner, laid down mats, and had my SUV buttoned up in 40 minutes. Everything was checked and ready before I went to bed.”</p>
             <cite>— Alicia M., Spring, TX</cite>
           </article>
           <article class="testimonial">


### PR DESCRIPTION
## Summary
- highlight included air and cabin filter checks along with tire pressure service in the offerings
- refresh pricing tiers with the new flat rates and note the $7.99 per-quart add-on after 5 quarts
- remove mentions of digital reports from service descriptions and testimonials

## Testing
- Not run (static content update)


------
https://chatgpt.com/codex/tasks/task_e_68d72cc1bbcc832e883f07e152ec7d62